### PR TITLE
dvbデバイス用のツールをmirakc:debianからコピーするように

### DIFF
--- a/docker-compose/mirakc/docker/Dockerfile
+++ b/docker-compose/mirakc/docker/Dockerfile
@@ -4,8 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libpcsclite-dev \
     pcscd \
-    pkg-config \
-    dvb-tools
+    pkg-config
 
 RUN npm install arib-b25-stream-test -g --unsafe 
 

--- a/docker-compose/mirakc/docker/Dockerfile
+++ b/docker-compose/mirakc/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN npm install arib-b25-stream-test -g --unsafe 
 
+COPY --from=docker.io/mirakc/mirakc:debian /usr/bin/dvbv5-zap /usr/bin/dvbv5-zap
 COPY --from=docker.io/mirakc/mirakc:debian /usr/local/bin/* /usr/local/bin/
 COPY --from=docker.io/mirakc/mirakc:debian /etc/mirakc/strings.yml /etc/mirakc/strings.yml
 ENV MIRAKC_CONFIG=/etc/mirakc/config.yml

--- a/docker-compose/mirakc/docker/Dockerfile
+++ b/docker-compose/mirakc/docker/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libpcsclite-dev \
     pcscd \
-    pkg-config
+    pkg-config \
+    dvb-tools
 
 RUN npm install arib-b25-stream-test -g --unsafe 
 


### PR DESCRIPTION
我が家の環境では、dvbv5-zapを利用して録画を行っているため
該当のツールをmirakc:debianからコピーするように変更しました。

検討よろしくお願いいたします。