### PR TITLE
dvbv5-zapで一部の動作にエラーが発生するのを修正

### DIFF
--- a/docker-compose/mirakc/docker/Dockerfile
+++ b/docker-compose/mirakc/docker/Dockerfile
@@ -4,11 +4,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libpcsclite-dev \
     pcscd \
-    pkg-config
+    pkg-config \
+    dvb-tools
 
 RUN npm install arib-b25-stream-test -g --unsafe 
 
-COPY --from=docker.io/mirakc/mirakc:debian /usr/bin/dvbv5-zap /usr/bin/dvbv5-zap
 COPY --from=docker.io/mirakc/mirakc:debian /usr/local/bin/* /usr/local/bin/
 COPY --from=docker.io/mirakc/mirakc:debian /etc/mirakc/strings.yml /etc/mirakc/strings.yml
 ENV MIRAKC_CONFIG=/etc/mirakc/config.yml


### PR DESCRIPTION
#42 にてバイナリをコピーするようにしていましたが、一部でエラーが発生してしまうため
パッケージマネージャから`dvb-tools`をインストールするように変更しました。

お手数おかけしますが、マージ宜しくお願い致します。